### PR TITLE
Make `style-loader` not crash in node

### DIFF
--- a/addStyle.js
+++ b/addStyle.js
@@ -2,7 +2,14 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+var isInBrowser = require('./isInBrowser');
+var emptyFunction = require('./emptyFunction');
+
 module.exports = function(cssCode) {
+	if (!isInBrowser()) {
+		return emptyFunction;
+	}
+
 	var styleElement = document.createElement("style");
 	styleElement.type = "text/css";
 	if (styleElement.styleSheet) {

--- a/addStyleUrl.js
+++ b/addStyleUrl.js
@@ -2,7 +2,14 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
+var isInBrowser = require('./isInBrowser');
+var emptyFunction = require('./emptyFunction');
+
 module.exports = function(cssUrl) {
+	if (!isInBrowser()) {
+		return emptyFunction;
+	}
+
 	var styleElement = document.createElement("link");
 	styleElement.rel = "stylesheet";
 	styleElement.type = "text/css";

--- a/emptyFunction.js
+++ b/emptyFunction.js
@@ -1,0 +1,2 @@
+/* Singleton empty function to reduce the amount of GC pressure */
+module.exports = function() {};

--- a/isInBrowser.js
+++ b/isInBrowser.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+	return typeof window !== 'undefined';
+};


### PR DESCRIPTION
**Warning: untested**

I think this'll work but I'm not sure if there's some test suite I should run or something.

The real solution for server-side rendering to prevent FOUC is to accumulate these into the head of the HTML response, but I think that's likely outside the scope of this loader. For now, I think we can get away with not crashing in Node. It'll at least make demos look good.

Does this belong in `style-loader` or should there be a new `isomorphic-style-loader`?
