### PR TITLE
Add a priority parameter to ensure correct loading order

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,16 @@ require("style!raw!./file.css");
 
 It's recommended to combine it with the [`css-loader`](https://github.com/webpack/css-loader): `require("style!css!./file.css")`.
 
-It also possible to add a URL instead of a css string:
+Specify a priority to ensure that higher-priority stylesheets are applied before lower-priority stylesheets (default priority is 0):
+
+```javascript
+require("style?priority=1!css!./theme.css");
+require("style!css!./default.css");
+
+// theme.css will be applied after default.css
+```
+
+It's also possible to add a URL instead of a css string:
 
 ``` javascript
 require("style/url!file!./file.css");

--- a/addStyle.js
+++ b/addStyle.js
@@ -2,19 +2,30 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-module.exports = function addStyle(cssCode) {
+module.exports = function addStyle(cssCode, priority) {
 	if(typeof DEBUG !== "undefined" && DEBUG) {
 		if(typeof document !== "object") throw new Error("The style-loader cannot be used in a non-browser environment");
 	}
 	var styleElement = document.createElement("style");
 	styleElement.type = "text/css";
+	styleElement.setAttribute("data-priority", priority);
 	if (styleElement.styleSheet) {
 		styleElement.styleSheet.cssText = cssCode;
 	} else {
 		styleElement.appendChild(document.createTextNode(cssCode));
 	}
+
 	var head = document.getElementsByTagName("head")[0];
-	head.appendChild(styleElement);
+	var styles = head.getElementsByTagName("style");
+	var before = null;
+	for (var i = 0; i < styles.length; i++) {
+	    var s = styles[i];
+	    if (s.type === "text/css" && (+s.getAttribute("data-priority")) > priority) {
+            before = s;
+	    }
+	}
+
+	head.insertBefore(styleElement, before);
 	return function() {
 		head.removeChild(styleElement);
 	};

--- a/addStyle.js
+++ b/addStyle.js
@@ -19,10 +19,10 @@ module.exports = function addStyle(cssCode, priority) {
 	var styles = head.getElementsByTagName("style");
 	var before = null;
 	for (var i = 0; i < styles.length; i++) {
-	    var s = styles[i];
-	    if (s.type === "text/css" && (+s.getAttribute("data-priority")) > priority) {
-            before = s;
-	    }
+		var s = styles[i];
+		if (s.type === "text/css" && (+s.getAttribute("data-priority")) > priority) {
+			before = s;
+		}
 	}
 
 	head.insertBefore(styleElement, before);

--- a/index.js
+++ b/index.js
@@ -3,14 +3,18 @@
 	Author Tobias Koppers @sokra
 */
 var path = require("path");
+var utils = require("loader-utils");
 module.exports = function() {};
 module.exports.pitch = function(remainingRequest) {
 	this.cacheable && this.cacheable();
+	var opts = utils.parseQuery(this.query);
+	var priority = JSON.stringify(+opts.priority || 0);
+
 	var comment1 = "// style-loader: Adds some css to the DOM by adding a <style> tag\n";
 	var addStyleCode = "var dispose = require(" + JSON.stringify("!" + path.join(__dirname, "addStyle.js")) + ")\n";
 	var comment2 = "\t// The css code:\n";
 	var cssCodeRequest = "require(" + JSON.stringify("!!" + remainingRequest) + ")";
 	var comment3 = "// Hot Module Replacement\n";
 	var hmrCode = "if(module.hot) {\n\tmodule.hot.accept();\n\tmodule.hot.dispose(dispose);\n}";
-	return comment1 + addStyleCode + comment2 + "\t(" + cssCodeRequest + ")\n" + hmrCode;
+	return comment1 + addStyleCode + comment2 + "\t(" + cssCodeRequest + ", " + priority + ")\n" + hmrCode;
 };

--- a/package.json
+++ b/package.json
@@ -1,16 +1,19 @@
 {
-	"name": "style-loader",
-	"version": "0.6.3",
-	"author": "Tobias Koppers @sokra",
-	"description": "style loader module for webpack",
-	"repository": {
-		"type": "git",
-		"url": "git@github.com:webpack/style-loader.git"
-	},
-	"licenses": [
-		{
-			"type": "MIT",
-			"url": "http://www.opensource.org/licenses/mit-license.php"
-		}
-	]
+  "name": "style-loader",
+  "version": "0.6.3",
+  "author": "Tobias Koppers @sokra",
+  "description": "style loader module for webpack",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:webpack/style-loader.git"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/mit-license.php"
+    }
+  ],
+  "dependencies": {
+    "loader-utils": "^0.2.2"
+  }
 }

--- a/useable.js
+++ b/useable.js
@@ -3,15 +3,19 @@
 	Author Tobias Koppers @sokra
 */
 var path = require("path");
+var utils = require("loader-utils");
 module.exports = function() {};
 module.exports.pitch = function(remainingRequest) {
 	this.cacheable && this.cacheable();
+	var opts = utils.parseQuery(this.query);
+	var priority = +opts.priority || 0;
+
 	return [
 		"var refs = 0;",
 		"var dispose;",
 		"exports.use = exports.ref = function() {",
 		"	if(!(refs++)) {",
-		"		dispose = require(" + JSON.stringify("!" + path.join(__dirname, "addStyle.js")) + ")(require(" + JSON.stringify("!!" + remainingRequest) + "));",
+		"		dispose = require(" + JSON.stringify("!" + path.join(__dirname, "addStyle.js")) + ")(require(" + JSON.stringify("!!" + remainingRequest) + "), " + JSON.stringify(priority) + ");",
 		"	}",
 		"	return exports",
 		"};",


### PR DESCRIPTION
This adds a `priority` parameter to the query that allows you to specify the priority of a stylesheet.

My use case for this is that I have a "theme" stylesheet that must be applied after the default styles in the app. The theme stylesheet must be defined in `head` after all the default styles, to allow theme styles to overwrite default styles. Due to dynamic loading, sometimes the default styles are `require`d after the theme is.

This change lets you specify a priority for a stylesheet. A stylesheet with a higher priority will always be loaded into `head` after all lower-priority stylesheets. The default priority is 0.
