### PR TITLE
[#39] Don't use styleSheet to store state of css text

### DIFF
--- a/addStyles.js
+++ b/addStyles.js
@@ -153,25 +153,20 @@ function addStyle(obj, options) {
 	};
 }
 
-function replaceText(source, id, replacement) {
-	var boundaries = ["/** >>" + id + " **/", "/** " + id + "<< **/"];
-	var start = source.lastIndexOf(boundaries[0]);
-	var wrappedReplacement = replacement
-		? (boundaries[0] + replacement + boundaries[1])
-		: "";
-	if (source.lastIndexOf(boundaries[0]) >= 0) {
-		var end = source.lastIndexOf(boundaries[1]) + boundaries[1].length;
-		return source.slice(0, start) + wrappedReplacement + source.slice(end);
-	} else {
-		return source + wrappedReplacement;
-	}
-}
+var replaceText = (function () {
+	var textStore = [];
+
+	return function (index, replacement) {
+		textStore[index] = replacement;
+		return textStore.filter(Boolean).join('\n');
+	};
+})();
 
 function applyToSingletonTag(styleElement, index, remove, obj) {
 	var css = remove ? "" : obj.css;
 
-	if(styleElement.styleSheet) {
-		styleElement.styleSheet.cssText = replaceText(styleElement.styleSheet.cssText, index, css);
+	if (styleElement.styleSheet) {
+		styleElement.styleSheet.cssText = replaceText(index, css);
 	} else {
 		var cssNode = document.createTextNode(css);
 		var childNodes = styleElement.childNodes;


### PR DESCRIPTION
IE9 will actually drop certain things (like media queries) from the
cssText property when it is read back out. To fix, store the raw css
text in a separately managed array, and use that to form the entire
string that should be set on the style element's cssText property.

Fixes #39.