### PR TITLE
Wrap sourceMap JSON in unescape and encodeURIComponent.

### DIFF
--- a/addStyles.js
+++ b/addStyles.js
@@ -204,7 +204,8 @@ function updateLink(linkElement, obj) {
 	var sourceMap = obj.sourceMap;
 
 	if(sourceMap) {
-		css += "\n/*# sourceMappingURL=data:application/json;base64," + btoa(JSON.stringify(sourceMap)) + " */";
+		// http://stackoverflow.com/a/26603875
+		css += "\n/*# sourceMappingURL=data:application/json;base64," + btoa(unescape(encodeURIComponent(JSON.stringify(sourceMap)))) + " */";
 	}
 
 	var blob = new Blob([css], { type: "text/css" });


### PR DESCRIPTION
Fixes error described here: http://stackoverflow.com/a/26603875. I can only reproduce the issue when style-loader is used together with autoprefixer-loader ^1.2.0 in this configuration:
```javascript
config.module.loaders.push({
    test: /\.scss$/,
    loaders: [
      "style-loader",
      "css-loader?sourceMap",
      "autoprefixer-loader",
      "sass-loader?sourceMap&sourceMapContents=true" + helpers.getScssIcludePathsAsArgs(),
    ],
  });
```
Perhaps the issue is with autoprefixer-loader? I'm not sure how to find the root cause.