### PR TITLE
update loader-utils dependency to 0.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     }
   ],
   "dependencies": {
-    "loader-utils": "^0.2.5"
+    "loader-utils": "^0.2.7"
   }
 }


### PR DESCRIPTION
since `stringifyRequest` was introduced in that version