### PR TITLE
fixes error in ie8

### DIFF
--- a/addStyles.js
+++ b/addStyles.js
@@ -157,8 +157,15 @@ var replaceText = (function () {
 	var textStore = [];
 
 	return function (index, replacement) {
+		var filtered = [];
 		textStore[index] = replacement;
-		return textStore.filter(Boolean).join('\n');
+		for(var i = 0; i < textStore.length; i++) {
+			if(textStore[i]) {
+				filtered.push(textStore[i]);
+			}
+		}
+
+		return filtered.join('\n');
 	};
 })();
 


### PR DESCRIPTION
IE8 Doesn't have Array.prototype.filter; the loader otherwise works amazingly well. If you want to continue functioning in IE8, please consider this PR.