### PR TITLE
Use license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,7 @@
     "type": "git",
     "url": "git@github.com:webpack/style-loader.git"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/mit-license.php"
-    }
-  ],
+  "license": "MIT",
   "dependencies": {
     "loader-utils": "^0.2.5"
   }


### PR DESCRIPTION
Array deprecated in `npm@2.10.0`

https://github.com/npm/npm/blob/master/doc/files/package.json.md#license