### PR TITLE
Added option to return complete object

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports.pitch = function(remainingRequest) {
 		"if(typeof content === 'string') content = [[module.id, content, '']];",
 		"// add the styles to the DOM",
 		"var update = require(" + loaderUtils.stringifyRequest(this, "!" + path.join(__dirname, "addStyles.js")) + ")(content, " + JSON.stringify(query) + ");",
-		"if(content.locals) module.exports = content.locals;",
+		query.returnComplete ? "if(content.locals) module.exports = content;" : "if(content.locals) module.exports = content.locals;",
 		"// Hot Module Replacement",
 		"if(module.hot) {",
 		"	// When the styles change, update the <style> tags",


### PR DESCRIPTION
We need this option to write code that can be used in both client and server side.
When building for server side rendering with `css-loader`, locals are accessed this way:

```JavaScript
var locals = require('style.css').locals;
document.write('<div class="' + locals.className + '"></div>');
```

However `style-loader`'s default behavior is to return locals directly, resulting in an error when the above code is run in browser. By using the `returnComplete` option users can opt for a behavior consistent with `css-loader`, making the above code run in both server and client side. 

Please let me know if there are other ways to achieve this.

Thanks,

Rick