### PR TITLE
Exporting locals from css-loader

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ module.exports.pitch = function(remainingRequest) {
 		"	}",
 		"	// When the module is disposed, remove the <style> tags",
 		"	module.hot.dispose(function() { update(); });",
+		" module.exports = content.locals || content;",
 		"}"
 	].join("\n");
 };


### PR DESCRIPTION
CSS Modules i really awesome (https://github.com/css-modules/webpack-demo), but you can not use it in combination with hot updates. It actually works, but the style-loader does not return the locals from the css-loader.

I have suggested a fix for this. Putting this together with react-transform and you got yourself an insanely powerful combo :-)

Old behaviour:

```js
import styles from './App.css';
styles // {}
```

New behaviour:

Old behaviour:

```js
import styles from './App.css';
styles // {Header: "Header_134135}
```