### PR TITLE
Fixed ordering of stylesheets inserted with insertAt=top.

### DIFF
--- a/addStyles.js
+++ b/addStyles.js
@@ -17,7 +17,8 @@ var stylesInDom = {},
 		return document.head || document.getElementsByTagName("head")[0];
 	}),
 	singletonElement = null,
-	singletonCounter = 0;
+	singletonCounter = 0,
+	styleElementsInsertedAtTop = [];
 
 module.exports = function(list, options) {
 	if(typeof DEBUG !== "undefined" && DEBUG) {
@@ -101,9 +102,15 @@ function listToStyles(list) {
 function createStyleElement(options) {
 	var styleElement = document.createElement("style");
 	var head = getHeadElement();
+	var lastStyleElementInsertedAtTop = styleElementsInsertedAtTop[styleElementsInsertedAtTop.length - 1];
 	styleElement.type = "text/css";
 	if (options.insertAt === "top") {
-		head.insertBefore(styleElement, head.firstChild);
+		if(lastStyleElementInsertedAtTop) {
+			head.insertBefore(styleElement, lastStyleElementInsertedAtTop.nextSibling);
+		} else {
+			head.insertBefore(styleElement, head.firstChild);
+		}
+		styleElementsInsertedAtTop.push(styleElement);
 	} else if (options.insertAt === "bottom") {
 		head.appendChild(styleElement);
 	} else {


### PR DESCRIPTION
This is in response to the issue brought up by @sokra in [PR 59](https://github.com/webpack/style-loader/pull/69).

> Could you do a follow-up PR that fix this, i. e. by storing a list of all top-inserted style tags and inserting after the last one.