### PR TITLE
drop unused vars

### DIFF
--- a/addStyles.js
+++ b/addStyles.js
@@ -211,7 +211,6 @@ function applyToSingletonTag(styleElement, index, remove, obj) {
 function applyToTag(styleElement, obj) {
 	var css = obj.css;
 	var media = obj.media;
-	var sourceMap = obj.sourceMap;
 
 	if(media) {
 		styleElement.setAttribute("media", media)
@@ -229,7 +228,6 @@ function applyToTag(styleElement, obj) {
 
 function updateLink(linkElement, obj) {
 	var css = obj.css;
-	var media = obj.media;
 	var sourceMap = obj.sourceMap;
 
 	if(sourceMap) {


### PR DESCRIPTION
in order to fix uglifyjs warnings
```
      Side effects in initialization of unused variable sourceMap [./~/style-loader/addStyles.js:185,0]
      Side effects in initialization of unused variable media [./~/style-loader/addStyles.js:203,0]
```