### PR TITLE
Replace window with self for better web worker support

### DIFF
--- a/addStyles.js
+++ b/addStyles.js
@@ -11,7 +11,7 @@ var stylesInDom = {},
 		};
 	},
 	isOldIE = memoize(function() {
-		return /msie [6-9]\b/.test(window.navigator.userAgent.toLowerCase());
+		return /msie [6-9]\b/.test(self.navigator.userAgent.toLowerCase());
 	}),
 	getHeadElement = memoize(function () {
 		return document.head || document.getElementsByTagName("head")[0];


### PR DESCRIPTION
Replacing `window` with `self` to better support web workers, they are the same thing in UI thread; https://developer.mozilla.org/en-US/docs/Web/API/Window/self.

This enables style loading in web worker context, for example by using this technique; https://github.com/web-perf/react-worker-dom/tree/r-15.