### PR TITLE
Add -loader suffix to reflect new loader syntax webpack 2 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ Adds CSS to the DOM by injecting a `<style>` tag
 ### Simple API
 
 ``` javascript
-require("style!raw!./file.css");
+require("style-loader!raw-loader!./file.css");
 // => add rules in file.css to document
 ```
 
-It's recommended to combine it with the [`css-loader`](https://github.com/webpack/css-loader): `require("style!css!./file.css")`.
+It's recommended to combine it with the [`css-loader`](https://github.com/webpack/css-loader): `require("style-loader!css-loader!./file.css")`.
 
 It's also possible to add a URL instead of a CSS string:
 
 ``` javascript
-require("style/url!file!./file.css");
+require("style-loader/url!file-loader!./file.css");
 // => add a <link rel="stylesheet"> to file.css to document
 ```
 
@@ -29,14 +29,14 @@ require("style/url!file!./file.css");
 When using [local scope CSS](https://github.com/webpack/css-loader#local-scope) the module exports the generated identifiers:
 
 ``` javascript
-var style = require("style!css!./file.css");
+var style = require("style-loader!css-loader!./file.css");
 style.placeholder1 === "z849f98ca812bc0d099a43e0f90184"
 ```
 
 ### Reference-counted API
 
 ``` javascript
-var style = require("style/useable!css!./file.css");
+var style = require("style-loader/useable!css-loader!./file.css");
 style.use(); // = style.ref();
 style.unuse(); // = style.unref();
 ```
@@ -65,8 +65,8 @@ So the recommended configuration for webpack is:
 {
   module: {
     loaders: [
-      { test: /\.css$/, exclude: /\.useable\.css$/, loader: "style!css" },
-      { test: /\.useable\.css$/, loader: "style/useable!css" }
+      { test: /\.css$/, exclude: /\.useable\.css$/, loader: "style-loader!css-loader" },
+      { test: /\.useable\.css$/, loader: "style-loader/useable!css-loader" }
     ]
   }
 }


### PR DESCRIPTION
Summary:
----

Webpack v2.1.0-beta.26 introduced a breaking change to require loaders to have the `-loader` suffix. 

This PR updates the README to show that pattern as an example instead of using the shorthand naming.

cc: @sokra 